### PR TITLE
Added the MPVolumeView to enable the Open-Measurement-SDKiOS to liste…

### DIFF
--- a/OM-Demo/BaseAdUnitViewController.swift
+++ b/OM-Demo/BaseAdUnitViewController.swift
@@ -38,6 +38,9 @@ class BaseAdUnitViewController: UIViewController {
         adContainerView.isHidden = true
         adContainerView.alpha = 0.0
         statusLabel.isHidden = true
+        
+        // Add this hidden volume slider to enable the OMSDK to listen for system volume
+        loadMPVolumeViewHidden()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -353,6 +356,12 @@ extension BaseAdUnitViewController {
             
             self.present(alert, animated: true, completion: nil)
         }
+    }
+    
+    func loadMPVolumeViewHidden() {
+        let volumeView = MPVolumeView(frame: view.bounds)
+        volumeView.isHidden = true
+        view.addSubview(volumeView)
     }
 }
 


### PR DESCRIPTION
This change, is to allow this notification to occur, the UI must contain an MPVolumeView.  Thus, I added the MPVolumeView to the Open-Measurement-ReferenceApp-iOS. This change must be tested on an actual device as the simulator did not reflect the volume changes.  This is all the Integrators must do to enable this functionality in the SDK.

I integrated the next suggestion to use AVSystemController_SystemVolumeDidChangeNotification. This is an undocumented function, but a quick Google search shows it is commonly used and people state Apple is allowing it into the App Store. However, this may not always be the case. To make this work, I had to add a new notification observer in the Open-Measurement-SDKiOS codebase in two places, OMIDVideoEvents.m and OMIDStateWatcher.m.  This allows the SDK to collect the system volume even when a WebView is used.  However, this must be enabled by the UI change for the MPVolumeView described below.  If the MPVolumeView is not added, then the above Notification callback is not called.  This is found in pull request https://github.com/InteractiveAdvertisingBureau/Open-Measurement-SDKiOS/compare/master...CaryPillers:OMSDK-499?expand=1.