### PR TITLE
[OMSDK-612] Support for split-screen and multi-window in iOS 13

### DIFF
--- a/OM-Demo.xcodeproj/project.pbxproj
+++ b/OM-Demo.xcodeproj/project.pbxproj
@@ -340,7 +340,6 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/OMSDK",
-					"$(PROJECT_DIR)/OMSDK/IABDemolab-Library",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.omid.reference;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -377,7 +376,6 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/OMSDK",
-					"$(PROJECT_DIR)/OMSDK/IABDemolab-Library",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.omid.reference;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/OM-Demo.xcodeproj/project.pbxproj
+++ b/OM-Demo.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		654DDD782086C53000BDAFF8 /* ImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654DDD772086C53000BDAFF8 /* ImageViewController.swift */; };
 		65A041B32081224C0033463C /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A041B22081224C0033463C /* Constants.swift */; };
 		65F0CE5F208AB09D00E6FDF4 /* BaseAdUnitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F0CE5E208AB09D00E6FDF4 /* BaseAdUnitViewController.swift */; };
+		A1A9E91623C922F900C87B03 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A9E91523C922F900C87B03 /* SceneDelegate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -36,6 +37,7 @@
 		654DDD772086C53000BDAFF8 /* ImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageViewController.swift; sourceTree = "<group>"; };
 		65A041B22081224C0033463C /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		65F0CE5E208AB09D00E6FDF4 /* BaseAdUnitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseAdUnitViewController.swift; sourceTree = "<group>"; };
+		A1A9E91523C922F900C87B03 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +87,7 @@
 				654DDD772086C53000BDAFF8 /* ImageViewController.swift */,
 				2B50FC63230CA493004CF05B /* AudioViewController.swift */,
 				38B305CA1F859D2B00557063 /* AppDelegate.swift */,
+				A1A9E91523C922F900C87B03 /* SceneDelegate.swift */,
 				38B305E61F859DDE00557063 /* LaunchScreen.storyboard */,
 				38B305E81F859DDE00557063 /* Main.storyboard */,
 				38B305D11F859D2B00557063 /* Assets.xcassets */,
@@ -169,6 +172,7 @@
 			files = (
 				65A041B32081224C0033463C /* Constants.swift in Sources */,
 				2B50FC64230CA493004CF05B /* AudioViewController.swift in Sources */,
+				A1A9E91623C922F900C87B03 /* SceneDelegate.swift in Sources */,
 				38B305E31F859DA500557063 /* WebViewController.swift in Sources */,
 				654DDD782086C53000BDAFF8 /* ImageViewController.swift in Sources */,
 				38B305E11F859DA500557063 /* AdListViewController.swift in Sources */,

--- a/OM-Demo/AppDelegate.swift
+++ b/OM-Demo/AppDelegate.swift
@@ -17,6 +17,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
+    // MARK: UIApplication Lifecycle (iOS 12 and older)
+
     func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
@@ -39,6 +41,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 
+    // MARK: UISceneSession Lifecycle (iOS 13 and newer)
+
+    @available(iOS 13.0, *)
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        let config = UISceneConfiguration()
+        config.delegateClass = SceneDelegate.self
+        config.storyboard = UIStoryboard(name: "Main", bundle: nil)
+        return config
+    }
+
+    @available(iOS 13.0, *)
+    func application(
+        _ application: UIApplication,
+        didDiscardSceneSessions sceneSessions: Set<UISceneSession>
+    ) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
 
 }
-

--- a/OM-Demo/Info.plist
+++ b/OM-Demo/Info.plist
@@ -2,6 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict/>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/OM-Demo/SceneDelegate.swift
+++ b/OM-Demo/SceneDelegate.swift
@@ -16,7 +16,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let _ = (scene as? UIWindowScene) else { return }
+
+        // To access associated window and/or screen objects, cast the scene to a UIWindowScene.
+        // guard let _ = (scene as? UIWindowScene) else { return }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/OM-Demo/SceneDelegate.swift
+++ b/OM-Demo/SceneDelegate.swift
@@ -1,0 +1,49 @@
+//
+//  SceneDelegate.swift
+//  OM-Demo
+//
+//  Created by Garo Hussenjian on 1/10/20.
+//
+
+import UIKit
+
+@available(iOS 13.0, *)
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not neccessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+}


### PR DESCRIPTION
Enable Reference app to run in split-screen or multi-window mode on iPadOS 13+.

![Simulator Screen Shot - iPad Pro (11-inch) - 2020-01-10 at 12 46 53](https://user-images.githubusercontent.com/535737/72185354-755ff780-33a7-11ea-9e86-807542e8d051.png)

Jira link: [OMSDK-612](https://theiab.atlassian.net/browse/OMSDK-612)